### PR TITLE
[ECDSA/GG20] Resharing issues

### DIFF
--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -53,12 +53,14 @@ func (round *round1) Start() *tss.Error {
 	}
 
 	// 2.
+	// Compute [v_i0, ..., v_it`], [s_i1, . . . , s_in`] ← FeldmanShare(g, w_i,t`, q, [p'_1, ...,p'_n'])
 	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
 	}
 
 	// 3.
+	// Compute [Ci, Di] = Commit([vi0, . . . , vit` ])
 	flatVis, err := crypto.FlattenECPoints(vi)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
@@ -94,9 +96,6 @@ func (round *round1) Update() (bool, *tss.Error) {
 	}
 	// accept messages from old -> new committee
 	for j, msg := range round.temp.dgRound1Messages {
-		if round.oldOK[j] {
-			continue
-		}
 		if msg == nil || !round.CanAccept(msg) {
 			return false, nil
 		}

--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -53,14 +53,14 @@ func (round *round1) Start() *tss.Error {
 	}
 
 	// 2.
-	// Compute [v_i0, ..., v_it`], [s_i1, . . . , s_in`] ← FeldmanShare(g, w_i,t`, q, [p'_1, ...,p'_n'])
+	// Compute [v_i0, ..., v_it`], [s_i1, ..., s_in`] ← FeldmanShare(g,w_i,t`,q,[k'_1, ...,k'_n'])
 	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
 	}
 
 	// 3.
-	// Compute [Ci, Di] = Commit([vi0, . . . , vit` ])
+	// Compute (C, D) = Commit([v_i0, . . . , v_it` ])
 	flatVis, err := crypto.FlattenECPoints(vi)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())

--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -52,15 +52,13 @@ func (round *round1) Start() *tss.Error {
 		return round.WrapError(err, round.PartyID())
 	}
 
-	// 2.
-	// Compute [v_i0, ..., v_it`], [s_i1, ..., s_in`] ← FeldmanShare(g,w_i,t`,q,[k'_1, ...,k'_n'])
+	// 2. Compute FeldmanVSS() -> [Vs: 0 - T_new], [s: 1 - N_new]
 	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
 	}
 
-	// 3.
-	// Compute (C, D) = Commit([v_i0, . . . , v_it` ])
+	// 3. Commit to generated shares -> (C, D)
 	flatVis, err := crypto.FlattenECPoints(vi)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())

--- a/ecdsa/resharing/round_3_old_step_2.go
+++ b/ecdsa/resharing/round_3_old_step_2.go
@@ -24,7 +24,6 @@ func (round *round3) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	// ~~round.allOldOK()~~ // old parties that are also in new committee also need to wait for D_i commitments
 
 	Pi := round.PartyID()
 	i := Pi.Index
@@ -33,15 +32,17 @@ func (round *round3) Start() *tss.Error {
 	for j, Pj := range round.NewParties().IDs() {
 		share := round.temp.NewShares[j]
 		r3msg1 := NewDGRound3Message1(Pj, round.PartyID(), share)
-		if i == j { // cache own share
+
+		if i != j { // send share_j directly to each player_j but yourself
+			round.out <- r3msg1
+		} else { // cache own share
 			round.temp.dgRound3Message1s[i] = r3msg1
 		}
-		round.out <- r3msg1
 	}
 
 	vDeCmt := round.temp.VD
 	r3msg2 := NewDGRound3Message2(
-		round.NewParties().IDs() /*.Exclude(round.PartyID())*/, round.PartyID(), // broadcast Di to **all** players in the new set
+		round.NewParties().IDs().Exclude(round.PartyID()), round.PartyID(),
 		vDeCmt)
 	round.temp.dgRound3Message2s[i] = r3msg2
 	round.out <- r3msg2
@@ -66,6 +67,9 @@ func (round *round3) Update() (bool, *tss.Error) {
 	}
 	// accept messages from old -> new committee
 	for j, msg1 := range round.temp.dgRound3Message1s {
+		if round.oldOK[j] {
+			continue
+		}
 		if msg1 == nil || !round.CanAccept(msg1) {
 			return false, nil
 		}


### PR DESCRIPTION
## Issue
Due to panic in round 2, it's impossible to reshare key when there's an overlap of players in the new and old committees.
A similar problem is described in the old issue [#128](https://github.com/bnb-chain/tss-lib/issues/128). 

If the original issue would be fixed, there will be a similar panic in round 4, and a few other inconsistencies in state replication.

## Rationale
Resharing mechanism implemented in the upstream library [`bnb-chain/tss-lib`](https://github.com/bnb-chain/tss-lib) isn't that what outlined on paper [CGGMP21](https://eprint.iacr.org/2021/060). 

The rationale described in the paper is to use a key refresh as a measure of proactive security, similar to regular key rotations in the conventional PKI. Whereas, existing implementations are keen to leverage this more for dealing with dynamic players committees, i.e. onboarding/offboarding.

Although developers do not describe protocol specifications on which their implementation is based, I found it very similar to what the Coinbase team is describing in their [pseudocode spec](https://github.com/coinbase/kryptology/blob/master/docs/Coinbase_Pseudocode_v5.pdf) for [`coinbase/kryptology`](https://github.com/coinbase/kryptology) library.

## Fixes
The proposed fix is based on `coinbase/kryptology` resharing protocol and my own debugging and understanding of the version that Binance's team implemented. A detailed description is available in the comments below.