### PR TITLE
Fix race condition of proceeding to round2 with unset key

### DIFF
--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -93,6 +93,10 @@ func (round *round1) Update() (bool, *tss.Error) {
 	}
 	// accept messages from old -> new committee
 	for j, msg := range round.temp.dgRound1Messages {
+		if round.oldOK[j] {
+			continue
+		}
+
 		if msg == nil || !round.CanAccept(msg) {
 			return false, nil
 		}

--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -36,7 +36,6 @@ func (round *round1) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	round.allOldOK()
 
 	Pi := round.PartyID()
 	i := Pi.Index


### PR DESCRIPTION
In round1 when we set all old and new statuses to OK and on the first update it immediately proceeds to round2 even though not all parties have set keys. This check prevents this race condition and waits for old parties to send the message in round1.